### PR TITLE
스토리지 저장 부분과 검색 기능을 조금 개선시켜 보았습니다 :)

### DIFF
--- a/src/components/Home/HomeComponent.js
+++ b/src/components/Home/HomeComponent.js
@@ -16,6 +16,13 @@ export default function HomeComponent() {
     onSelect,
   } = useContext(HomeContext);
 
+  let items = []; // Object 형태로 각기 저장되어 있는 storage 데이터를 하나의 배열로 합침
+  for (const key in persistItems) {
+    if (key.includes(value)) {
+      items = [...items, ...persistItems[key]];
+    }
+  }
+
   return (
     <div className="home-style">
       <div className="home-style__searchBox">
@@ -44,11 +51,10 @@ export default function HomeComponent() {
             loading={loading}
             value={value}
             onScrollSearch={onScrollSearch}
-            items={
-              persistItems[value]
-              // persistItems.filter(
-              //   (ele) => ele?.keyword === value && ele?.items
-              // )[0]?.items
+            items={ 
+              items.filter((item1, index) => 
+              index === items.findIndex((item2) =>  // 중복되는 계정을 제거
+              item1.id === item2.id))
             }
           />
         )}

--- a/src/store/modules/storage/storageModule.js
+++ b/src/store/modules/storage/storageModule.js
@@ -18,21 +18,14 @@ export const INITIAL_STATE = {
 const reducer = createReducer(INITIAL_STATE, {
   [types.ON_STORAGE_SUCCESS]: (state, action) => {
     console.log({ action }, "persist@@#@#@#@");
-    const {
-      value,
-      total_count = 0,
-      items = 0,
-      incomplete_results = false,
-    } = action.payload;
+    const { value, total_count = 0, items = 0, incomplete_results = false } = action.payload;
 
     if (items.length) {
       if (
         state.data.persistItems[value] &&
-        !state.data.persistItems[value].includes(items[0])
+        !state.data.persistItems[value].find(persistItem => persistItem.id === items[0].id)
       ) {
-        state.data.persistItems[value] = state.data.persistItems[value].concat(
-          items
-        );
+        state.data.persistItems[value] = state.data.persistItems[value].concat(items);
       } else {
         state.data.persistItems[value] = items;
       }


### PR DESCRIPTION
# 작업한 사항
## 유저 검색 후 스토리지 저장 방식
(**1번 사항**) 유저 검색 시, 이미 기존에 스토리지에 해당 키워드에 대한 데이터가 저장이 되어있는지 여부와 상관없이 무조건 계속해서 중복 저장이 됨.
이 부분을 해당 키워드에 대한 계정 정보가 이미 저장되어 있으면 저장하지 못하도록 변경.

## 스토리지 내 검색 기능
(**2번 사항**) 저장된 스토리지의 데이터 검색 시, 검색했던 키 값이 동일해야 검색 결과가 나옴. 
이 부분을 유사한 키워드이면 모두 검색이 되도록 변경.

(**3번 사항**) 위 작업으로 인해, 다른 키워드로 검색해서 나온 동일한 계정이 중복되서 나타남.
이 부분을 중복된 계정이면 한번만 나오도록 변경.